### PR TITLE
feat: UI 3D com aceleração Metal (SceneKit)

### DIFF
--- a/GameNet/Presentation/Components/ThreeD/AnnualGameplaySurface3DView.swift
+++ b/GameNet/Presentation/Components/ThreeD/AnnualGameplaySurface3DView.swift
@@ -1,0 +1,220 @@
+//
+//  AnnualGameplaySurface3DView.swift
+//  GameNet
+//
+//  Superfície 3D do progresso anual de gameplay (Metal/SceneKit).
+//  Eixos: dia do ano (X), minutos acumulados (Y), ano (Z).
+//
+
+import SceneKit
+import SwiftUI
+
+struct AnnualGameplaySurface3DView: View {
+    let series: [AnnualGameplayProgressSeries]
+    var onSelectYear: ((Int) -> Void)?
+
+    @State private var selectedYear: Int?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            #if os(iOS)
+            AnnualGameplaySurfaceSceneView(
+                series: series,
+                selectedYear: $selectedYear
+            )
+            .frame(height: 260)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            #else
+            Text("Visualização 3D disponível no iOS")
+                .frame(height: 260)
+            #endif
+
+            if let selectedYear,
+               let selected = series.first(where: { $0.year == selectedYear }) {
+                HStack {
+                    Text("Ano \(selected.year)")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text("\(Int(selected.totalMinutes)) min")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let onSelectYear {
+                    Button("Ver sessões de \(selected.year)") {
+                        onSelectYear(selected.year)
+                    }
+                    .font(.footnote)
+                }
+            } else {
+                Text("Gire a cena • toque em uma trilha para selecionar o ano")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+#if os(iOS)
+struct AnnualGameplaySurfaceSceneView: UIViewRepresentable {
+    let series: [AnnualGameplayProgressSeries]
+    @Binding var selectedYear: Int?
+
+    func makeUIView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        scnView.backgroundColor = .clear
+        scnView.isOpaque = false
+        scnView.antialiasingMode = .multisampling4X
+        scnView.autoenablesDefaultLighting = true
+        scnView.allowsCameraControl = true
+        scnView.defaultCameraController.interactionMode = .orbitTurntable
+        scnView.preferredFramesPerSecond = 60
+
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        scnView.addGestureRecognizer(tap)
+        context.coordinator.scnView = scnView
+
+        scnView.scene = makeScene()
+        return scnView
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {
+        uiView.scene = makeScene()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selectedYear: $selectedYear)
+    }
+
+    private func makeScene() -> SCNScene {
+        let scene = SCNScene()
+
+        let camera = SCNNode()
+        camera.camera = SCNCamera()
+        camera.camera?.wantsHDR = true
+        camera.position = SCNVector3(0, 4, 8)
+        camera.look(at: SCNVector3(0, 1, 0))
+        scene.rootNode.addChildNode(camera)
+
+        let ambient = SCNNode()
+        ambient.light = SCNLight()
+        ambient.light?.type = .ambient
+        ambient.light?.intensity = 300
+        scene.rootNode.addChildNode(ambient)
+
+        let key = SCNNode()
+        key.light = SCNLight()
+        key.light?.type = .directional
+        key.light?.intensity = 850
+        key.eulerAngles = SCNVector3(-0.9, 0.4, 0)
+        scene.rootNode.addChildNode(key)
+
+        let maxMinutes = max(series.map(\.totalMinutes).max() ?? 1, 1)
+        let colors: [UIColor] = [
+            .systemTeal, .systemIndigo, .systemOrange, .systemPink, .systemGreen, .systemPurple
+        ]
+
+        for (yearIndex, yearSeries) in series.enumerated() {
+            let z = Float(yearIndex) * 1.1 - Float(series.count - 1) * 0.55
+            let color = colors[yearIndex % colors.count]
+            let sampled = samplePoints(yearSeries.points, stride: 3)
+
+            guard sampled.count > 1 else { continue }
+
+            var previous: SCNVector3?
+            for point in sampled {
+                let x = (Float(point.day) / 366.0) * 6.0 - 3.0
+                let y = Float(point.cumulativeMinutes / maxMinutes) * 3.0
+                let position = SCNVector3(x, y, z)
+
+                if let previous {
+                    let segment = makeSegment(from: previous, to: position, color: color)
+                    segment.name = "year-\(yearSeries.year)"
+                    scene.rootNode.addChildNode(segment)
+                }
+                previous = position
+            }
+
+            // End marker
+            if let last = previous {
+                let sphere = SCNSphere(radius: 0.08)
+                let material = SCNMaterial()
+                material.diffuse.contents = color
+                sphere.materials = [material]
+                let marker = SCNNode(geometry: sphere)
+                marker.position = last
+                marker.name = "year-\(yearSeries.year)"
+                scene.rootNode.addChildNode(marker)
+            }
+        }
+
+        // Base plane
+        let base = SCNPlane(width: 7, height: Float(max(series.count, 1)) * 1.2)
+        let baseMaterial = SCNMaterial()
+        baseMaterial.diffuse.contents = UIColor(white: 0.14, alpha: 0.9)
+        baseMaterial.isDoubleSided = true
+        base.materials = [baseMaterial]
+        let baseNode = SCNNode(geometry: base)
+        baseNode.eulerAngles = SCNVector3(-Float.pi / 2, 0, 0)
+        baseNode.position = SCNVector3(0, 0, 0)
+        scene.rootNode.addChildNode(baseNode)
+
+        return scene
+    }
+
+    private func samplePoints(
+        _ points: [AnnualGameplayProgressPoint],
+        stride: Int
+    ) -> [AnnualGameplayProgressPoint] {
+        guard !points.isEmpty else { return [] }
+        var result: [AnnualGameplayProgressPoint] = []
+        for (index, point) in points.enumerated() where index % stride == 0 {
+            result.append(point)
+        }
+        if let last = points.last, result.last?.id != last.id {
+            result.append(last)
+        }
+        return result
+    }
+
+    private func makeSegment(from: SCNVector3, to: SCNVector3, color: UIColor) -> SCNNode {
+        let vector = SCNVector3(to.x - from.x, to.y - from.y, to.z - from.z)
+        let distance = sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z)
+        let cylinder = SCNCylinder(radius: 0.025, height: CGFloat(distance))
+        let material = SCNMaterial()
+        material.diffuse.contents = color
+        material.lightingModel = .physicallyBased
+        cylinder.materials = [material]
+
+        let node = SCNNode(geometry: cylinder)
+        node.position = SCNVector3(
+            (from.x + to.x) / 2,
+            (from.y + to.y) / 2,
+            (from.z + to.z) / 2
+        )
+        node.look(at: to, up: SCNVector3(0, 1, 0), localFront: SCNVector3(0, 1, 0))
+        return node
+    }
+
+    final class Coordinator: NSObject {
+        var selectedYear: Binding<Int?>
+        weak var scnView: SCNView?
+
+        init(selectedYear: Binding<Int?>) {
+            self.selectedYear = selectedYear
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scnView else { return }
+            let location = gesture.location(in: scnView)
+            let hits = scnView.hitTest(location, options: nil)
+            guard let name = hits.first?.node.name,
+                  name.hasPrefix("year-"),
+                  let year = Int(name.replacingOccurrences(of: "year-", with: "")) else {
+                return
+            }
+            selectedYear.wrappedValue = year
+        }
+    }
+}
+#endif

--- a/GameNet/Presentation/Components/ThreeD/Cover3DTransition.swift
+++ b/GameNet/Presentation/Components/ThreeD/Cover3DTransition.swift
@@ -1,0 +1,74 @@
+//
+//  Cover3DTransition.swift
+//  GameNet
+//
+//  Transição 3D capa → detalhe: a caixa "levanta" e gira ao entrar no hero.
+//
+
+import SceneKit
+import SwiftUI
+
+enum Cover3DTransitionStyle {
+    case none
+    case liftAndTurn
+}
+
+struct Cover3DEntranceModifier: ViewModifier {
+    let style: Cover3DTransitionStyle
+    @State private var appeared = false
+
+    func body(content: Content) -> some View {
+        content
+            .rotation3DEffect(
+                .degrees(appeared || style == .none ? 0 : 18),
+                axis: (x: 0.15, y: 1, z: 0),
+                anchor: .center,
+                perspective: 0.55
+            )
+            .scaleEffect(appeared || style == .none ? 1 : 0.86)
+            .offset(y: appeared || style == .none ? 0 : 24)
+            .opacity(appeared || style == .none ? 1 : 0.0)
+            .onAppear {
+                guard style != .none else { return }
+                withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                    appeared = true
+                }
+            }
+            .onDisappear {
+                appeared = false
+            }
+    }
+}
+
+extension View {
+    /// Aplica a transição 3D de entrada da capa no detalhe do jogo.
+    func cover3DEntrance(_ style: Cover3DTransitionStyle = .liftAndTurn) -> some View {
+        modifier(Cover3DEntranceModifier(style: style))
+    }
+}
+
+#if os(iOS)
+/// Anima o nó da capa no SceneKit ao entrar na tela de detalhe.
+enum Cover3DSceneTransition {
+    static func playEntrance(on boxNode: SCNNode) {
+        boxNode.eulerAngles = SCNVector3(0.35, 0.9, 0)
+        boxNode.scale = SCNVector3(0.7, 0.7, 0.7)
+        boxNode.position = SCNVector3(0, -0.35, 0)
+
+        let rotate = SCNAction.rotateTo(
+            x: 0.05,
+            y: 0,
+            z: 0,
+            duration: 0.55,
+            usesShortestUnitArc: true
+        )
+        let scale = SCNAction.scale(to: 1.0, duration: 0.55)
+        let move = SCNAction.move(to: SCNVector3(0, 0, 0), duration: 0.55)
+        rotate.timingMode = .easeOut
+        scale.timingMode = .easeOut
+        move.timingMode = .easeOut
+
+        boxNode.runAction(.group([rotate, scale, move]))
+    }
+}
+#endif

--- a/GameNet/Presentation/Components/ThreeD/CoverImageLoader.swift
+++ b/GameNet/Presentation/Components/ThreeD/CoverImageLoader.swift
@@ -1,0 +1,41 @@
+//
+//  CoverImageLoader.swift
+//  GameNet
+//
+//  Carrega capas remotas em UIImage para texturizar cenas Metal/SceneKit.
+//
+
+import Foundation
+import UIKit
+
+enum CoverImageLoader {
+    private static let cache = NSCache<NSString, UIImage>()
+
+    static func image(from urlString: String) async -> UIImage? {
+        guard !urlString.isEmpty else { return nil }
+
+        let key = urlString as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        guard let url = URL(string: urlString) else { return nil }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard let image = UIImage(data: data) else { return nil }
+            cache.setObject(image, forKey: key)
+            return image
+        } catch {
+            return nil
+        }
+    }
+
+    static func placeholder(size: CGSize = CGSize(width: 200, height: 300)) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            UIColor.secondarySystemFill.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/GameNet/Presentation/Components/ThreeD/GameCover3DView.swift
+++ b/GameNet/Presentation/Components/ThreeD/GameCover3DView.swift
@@ -17,6 +17,7 @@ struct GameCover3DView: View {
     var cornerRadius: CGFloat = 12
     var enablesMotion: Bool = true
     var autoRotate: Bool = false
+    var playsEntranceTransition: Bool = false
 
     @State private var coverImage: UIImage?
     @State private var isLoading = true
@@ -27,7 +28,8 @@ struct GameCover3DView: View {
             GameCoverSceneKitView(
                 coverImage: coverImage ?? CoverImageLoader.placeholder(),
                 enablesMotion: enablesMotion,
-                autoRotate: autoRotate
+                autoRotate: autoRotate,
+                playsEntranceTransition: playsEntranceTransition
             )
 
             if isLoading {
@@ -37,6 +39,7 @@ struct GameCover3DView: View {
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .cover3DEntrance(playsEntranceTransition ? .liftAndTurn : .none)
         .task(id: coverURL) {
             isLoading = true
             coverImage = await CoverImageLoader.image(from: coverURL)

--- a/GameNet/Presentation/Components/ThreeD/GameCover3DView.swift
+++ b/GameNet/Presentation/Components/ThreeD/GameCover3DView.swift
@@ -78,6 +78,7 @@ struct GameCoverSceneKitView: UIViewRepresentable {
     let coverImage: UIImage
     var enablesMotion: Bool
     var autoRotate: Bool
+    var playsEntranceTransition: Bool
 
     func makeUIView(context: Context) -> SCNView {
         let scnView = SCNView()
@@ -92,7 +93,17 @@ struct GameCoverSceneKitView: UIViewRepresentable {
         context.coordinator.boxNode = scnView.scene?.rootNode.childNode(withName: "coverBox", recursively: false)
         context.coordinator.autoRotate = autoRotate
 
-        if enablesMotion {
+        if playsEntranceTransition, let box = context.coordinator.boxNode {
+            Cover3DSceneTransition.playEntrance(on: box)
+            // Inicia motion/auto-rotate após a entrada
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                if enablesMotion {
+                    context.coordinator.startMotion()
+                } else if autoRotate {
+                    context.coordinator.startAutoRotate()
+                }
+            }
+        } else if enablesMotion {
             context.coordinator.startMotion()
         } else if autoRotate {
             context.coordinator.startAutoRotate()

--- a/GameNet/Presentation/Components/ThreeD/GameCover3DView.swift
+++ b/GameNet/Presentation/Components/ThreeD/GameCover3DView.swift
@@ -1,0 +1,222 @@
+//
+//  GameCover3DView.swift
+//  GameNet
+//
+//  Caa 3D (caixa/cartucho) acelerada por Metal via SceneKit,
+//  com parallax leve pelo giroscópio.
+//
+
+import CoreMotion
+import SceneKit
+import SwiftUI
+
+// MARK: - GameCover3DView
+
+struct GameCover3DView: View {
+    let coverURL: String
+    var cornerRadius: CGFloat = 12
+    var enablesMotion: Bool = true
+    var autoRotate: Bool = false
+
+    @State private var coverImage: UIImage?
+    @State private var isLoading = true
+
+    var body: some View {
+        #if os(iOS)
+        ZStack {
+            GameCoverSceneKitView(
+                coverImage: coverImage ?? CoverImageLoader.placeholder(),
+                enablesMotion: enablesMotion,
+                autoRotate: autoRotate
+            )
+
+            if isLoading {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(Color.secondary.opacity(0.2))
+                    .redacted(reason: .placeholder)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .task(id: coverURL) {
+            isLoading = true
+            coverImage = await CoverImageLoader.image(from: coverURL)
+            isLoading = false
+        }
+        #else
+        CachedAsyncImageFallback(coverURL: coverURL, cornerRadius: cornerRadius)
+        #endif
+    }
+}
+
+#if !os(iOS)
+import CachedAsyncImage
+
+private struct CachedAsyncImageFallback: View {
+    let coverURL: String
+    let cornerRadius: CGFloat
+
+    var body: some View {
+        CachedAsyncImage(url: URL(string: coverURL)) { image in
+            image
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        } placeholder: {
+            ProgressView()
+        }
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+    }
+}
+#endif
+
+// MARK: - SceneKit bridge
+
+#if os(iOS)
+struct GameCoverSceneKitView: UIViewRepresentable {
+    let coverImage: UIImage
+    var enablesMotion: Bool
+    var autoRotate: Bool
+
+    func makeUIView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        scnView.scene = makeScene(coverImage: coverImage)
+        scnView.backgroundColor = .clear
+        scnView.isOpaque = false
+        scnView.antialiasingMode = .multisampling4X
+        scnView.autoenablesDefaultLighting = true
+        scnView.allowsCameraControl = false
+        scnView.preferredFramesPerSecond = 60
+
+        context.coordinator.boxNode = scnView.scene?.rootNode.childNode(withName: "coverBox", recursively: false)
+        context.coordinator.autoRotate = autoRotate
+
+        if enablesMotion {
+            context.coordinator.startMotion()
+        } else if autoRotate {
+            context.coordinator.startAutoRotate()
+        }
+
+        return scnView
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {
+        guard let box = uiView.scene?.rootNode.childNode(withName: "coverBox", recursively: false) else {
+            return
+        }
+
+        applyCoverMaterial(to: box, image: coverImage)
+        context.coordinator.boxNode = box
+        context.coordinator.autoRotate = autoRotate
+    }
+
+    static func dismantleUIView(_ uiView: SCNView, coordinator: Coordinator) {
+        coordinator.stop()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    // MARK: Scene
+
+    private func makeScene(coverImage: UIImage) -> SCNScene {
+        let scene = SCNScene()
+
+        let cameraNode = SCNNode()
+        cameraNode.camera = SCNCamera()
+        cameraNode.camera?.wantsHDR = true
+        cameraNode.position = SCNVector3(0, 0, 3.2)
+        scene.rootNode.addChildNode(cameraNode)
+
+        let ambient = SCNNode()
+        ambient.light = SCNLight()
+        ambient.light?.type = .ambient
+        ambient.light?.intensity = 400
+        scene.rootNode.addChildNode(ambient)
+
+        let keyLight = SCNNode()
+        keyLight.light = SCNLight()
+        keyLight.light?.type = .directional
+        keyLight.light?.intensity = 800
+        keyLight.eulerAngles = SCNVector3(-0.6, 0.4, 0)
+        scene.rootNode.addChildNode(keyLight)
+
+        let box = SCNBox(width: 1.0, height: 1.5, length: 0.1, chamferRadius: 0.02)
+        let boxNode = SCNNode(geometry: box)
+        boxNode.name = "coverBox"
+        applyCoverMaterial(to: boxNode, image: coverImage)
+        scene.rootNode.addChildNode(boxNode)
+
+        return scene
+    }
+
+    private func applyCoverMaterial(to node: SCNNode, image: UIImage) {
+        guard let box = node.geometry as? SCNBox else { return }
+
+        let front = SCNMaterial()
+        front.diffuse.contents = image
+        front.lightingModel = .physicallyBased
+        front.roughness.contents = 0.55
+        front.metalness.contents = 0.05
+
+        let spine = SCNMaterial()
+        spine.diffuse.contents = UIColor(white: 0.15, alpha: 1)
+        spine.lightingModel = .physicallyBased
+        spine.roughness.contents = 0.7
+
+        let back = SCNMaterial()
+        back.diffuse.contents = UIColor(white: 0.08, alpha: 1)
+        back.lightingModel = .physicallyBased
+
+        // SCNBox materials: front, right, back, left, top, bottom
+        box.materials = [front, spine, back, spine, spine, spine]
+    }
+
+    // MARK: Coordinator
+
+    final class Coordinator {
+        var boxNode: SCNNode?
+        var autoRotate = false
+        private let motionManager = CMMotionManager()
+        private var displayLink: CADisplayLink?
+        private var autoAngle: Float = 0
+
+        func startMotion() {
+            guard motionManager.isDeviceMotionAvailable else {
+                startAutoRotate()
+                return
+            }
+
+            motionManager.deviceMotionUpdateInterval = 1.0 / 60.0
+            motionManager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
+                guard let self, let motion, let boxNode else { return }
+                let roll = Float(motion.attitude.roll) * 0.35
+                let pitch = Float(motion.attitude.pitch) * 0.25
+                boxNode.eulerAngles = SCNVector3(pitch, roll, 0)
+            }
+        }
+
+        func startAutoRotate() {
+            stopDisplayLink()
+            let link = CADisplayLink(target: self, selector: #selector(tickAutoRotate))
+            link.add(to: .main, forMode: .common)
+            displayLink = link
+        }
+
+        @objc private func tickAutoRotate() {
+            guard let boxNode else { return }
+            autoAngle += 0.01
+            boxNode.eulerAngles = SCNVector3(0.1, sin(autoAngle) * 0.35, 0)
+        }
+
+        func stop() {
+            motionManager.stopDeviceMotionUpdates()
+            stopDisplayLink()
+        }
+
+        private func stopDisplayLink() {
+            displayLink?.invalidate()
+            displayLink = nil
+        }
+    }
+}
+#endif

--- a/GameNet/Presentation/Components/ThreeD/GameplaySessionsMap3DView.swift
+++ b/GameNet/Presentation/Components/ThreeD/GameplaySessionsMap3DView.swift
@@ -1,0 +1,192 @@
+//
+//  GameplaySessionsMap3DView.swift
+//  GameNet
+//
+//  Mapa 3D de sessões de um jogo: altura = duração, posição = ordem temporal.
+//
+
+import SceneKit
+import SwiftUI
+
+struct GameplaySessionsMap3DView: View {
+    let sessions: [GameplaySession]
+    var accentColor: Color = .main
+    var isActiveSession: ((GameplaySession) -> Bool)?
+
+    @State private var selectedSessionId: String?
+
+    private var selectedSession: GameplaySession? {
+        sessions.first { ($0.id ?? "") == selectedSessionId }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Mapa de Sessões")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            #if os(iOS)
+            GameplaySessionsMapSceneView(
+                sessions: sessions,
+                accent: UIColor(accentColor),
+                selectedSessionId: $selectedSessionId,
+                isActiveSession: isActiveSession
+            )
+            .frame(height: 200)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            #else
+            Text("Visualização 3D disponível no iOS")
+                .frame(height: 200)
+            #endif
+
+            if let selectedSession {
+                VStack(alignment: .leading, spacing: 4) {
+                    if selectedSession.finish == nil {
+                        Text("Em andamento")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.green)
+                    }
+                    Text(selectedSession.start.toFormattedString(dateFormat: GameNetApp.dateTimeFormat))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if selectedSession.finish != nil {
+                        Text(selectedSession.totalGameplayTime)
+                            .font(.caption.weight(.semibold))
+                    }
+                }
+            } else {
+                Text("Toque em um bloco para ver a sessão")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+#if os(iOS)
+struct GameplaySessionsMapSceneView: UIViewRepresentable {
+    let sessions: [GameplaySession]
+    let accent: UIColor
+    @Binding var selectedSessionId: String?
+    var isActiveSession: ((GameplaySession) -> Bool)?
+
+    func makeUIView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        scnView.backgroundColor = .clear
+        scnView.isOpaque = false
+        scnView.antialiasingMode = .multisampling4X
+        scnView.autoenablesDefaultLighting = true
+        scnView.allowsCameraControl = true
+        scnView.defaultCameraController.interactionMode = .orbitTurntable
+        scnView.preferredFramesPerSecond = 60
+
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        scnView.addGestureRecognizer(tap)
+        context.coordinator.scnView = scnView
+        scnView.scene = makeScene()
+        return scnView
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {
+        uiView.scene = makeScene()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selectedSessionId: $selectedSessionId)
+    }
+
+    private func makeScene() -> SCNScene {
+        let scene = SCNScene()
+
+        let camera = SCNNode()
+        camera.camera = SCNCamera()
+        camera.position = SCNVector3(0, 3, 7)
+        camera.look(at: SCNVector3(0, 0.8, 0))
+        scene.rootNode.addChildNode(camera)
+
+        let ambient = SCNNode()
+        ambient.light = SCNLight()
+        ambient.light?.type = .ambient
+        ambient.light?.intensity = 300
+        scene.rootNode.addChildNode(ambient)
+
+        let key = SCNNode()
+        key.light = SCNLight()
+        key.light?.type = .directional
+        key.light?.intensity = 900
+        key.eulerAngles = SCNVector3(-0.8, 0.3, 0)
+        scene.rootNode.addChildNode(key)
+
+        let chronological = sessions.sorted { $0.start < $1.start }
+        let durations = chronological.map { durationMinutes(for: $0) }
+        let maxDuration = max(durations.max() ?? 1, 1)
+
+        let columns = min(8, max(chronological.count, 1))
+        for (index, session) in chronological.enumerated() {
+            let row = index / columns
+            let col = index % columns
+            let x = Float(col) * 0.7 - Float(columns - 1) * 0.35
+            let z = -Float(row) * 0.8
+            let minutes = durations[index]
+            let height = max(0.2, Float(minutes / maxDuration) * 2.5)
+
+            let box = SCNBox(width: 0.45, height: CGFloat(height), length: 0.45, chamferRadius: 0.04)
+            let material = SCNMaterial()
+            let active = isActiveSession?(session) == true || session.finish == nil
+            material.diffuse.contents = active ? UIColor.systemGreen : accent
+            material.lightingModel = .physicallyBased
+            material.roughness.contents = 0.5
+            if active {
+                material.emission.contents = UIColor.systemGreen.withAlphaComponent(0.35)
+            }
+            box.materials = [material]
+
+            let node = SCNNode(geometry: box)
+            node.position = SCNVector3(x, height / 2, z)
+            node.name = session.id ?? "session-\(index)"
+            scene.rootNode.addChildNode(node)
+
+            if active {
+                let pulse = SCNAction.repeatForever(
+                    .sequence([
+                        .customAction(duration: 0.8) { node, elapsed in
+                            let t = Float(elapsed / 0.8)
+                            let opacity = 0.55 + 0.45 * sin(t * .pi)
+                            node.geometry?.firstMaterial?.emission.intensity = CGFloat(opacity)
+                        },
+                        .customAction(duration: 0.8) { node, elapsed in
+                            let t = Float(elapsed / 0.8)
+                            let opacity = 0.55 + 0.45 * sin((1 - t) * .pi)
+                            node.geometry?.firstMaterial?.emission.intensity = CGFloat(opacity)
+                        }
+                    ])
+                )
+                node.runAction(pulse)
+            }
+        }
+
+        return scene
+    }
+
+    private func durationMinutes(for session: GameplaySession) -> Double {
+        let end = session.finish ?? Date()
+        return max(end.timeIntervalSince(session.start) / 60.0, 1)
+    }
+
+    final class Coordinator: NSObject {
+        var selectedSessionId: Binding<String?>
+        weak var scnView: SCNView?
+
+        init(selectedSessionId: Binding<String?>) {
+            self.selectedSessionId = selectedSessionId
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scnView else { return }
+            let hits = scnView.hitTest(gesture.location(in: scnView), options: nil)
+            guard let name = hits.first?.node.name else { return }
+            selectedSessionId.wrappedValue = name
+        }
+    }
+}
+#endif

--- a/GameNet/Presentation/Components/ThreeD/PlatformsIslands3DView.swift
+++ b/GameNet/Presentation/Components/ThreeD/PlatformsIslands3DView.swift
@@ -1,0 +1,191 @@
+//
+//  PlatformsIslands3DView.swift
+//  GameNet
+//
+//  Distribuição de jogos por plataforma como "ilhas" 3D (Metal/SceneKit).
+//
+
+import SceneKit
+import SwiftUI
+
+struct PlatformsIslands3DView: View {
+    let platforms: [PlatformGame]
+    var total: Int
+
+    @State private var selectedPlatformId: String?
+
+    private var selectedPlatform: PlatformGame? {
+        platforms.first { ($0.id ?? $0.name) == selectedPlatformId }
+    }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.tertiaryCardBackground)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Jogos por Plataforma")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.cardTitle)
+
+                Text("\(total) jogos no total")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                #if os(iOS)
+                PlatformsIslandsSceneView(
+                    platforms: platforms,
+                    selectedPlatformId: $selectedPlatformId
+                )
+                .frame(height: 240)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                #else
+                Text("Visualização 3D disponível no iOS")
+                    .frame(height: 240)
+                #endif
+
+                if let selectedPlatform {
+                    HStack {
+                        Text(selectedPlatform.name)
+                            .font(.headline)
+                        Spacer()
+                        Text("\(selectedPlatform.platformGamesTotal)")
+                            .font(.headline)
+                    }
+                } else {
+                    Text("Toque em uma ilha para ver a plataforma")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding()
+        }
+        .padding()
+    }
+}
+
+#if os(iOS)
+struct PlatformsIslandsSceneView: UIViewRepresentable {
+    let platforms: [PlatformGame]
+    @Binding var selectedPlatformId: String?
+
+    private let palette: [UIColor] = [
+        .systemTeal, .systemIndigo, .systemOrange, .systemPink,
+        .systemGreen, .systemPurple, .systemBlue, .systemYellow
+    ]
+
+    func makeUIView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        scnView.backgroundColor = .clear
+        scnView.isOpaque = false
+        scnView.antialiasingMode = .multisampling4X
+        scnView.autoenablesDefaultLighting = true
+        scnView.allowsCameraControl = true
+        scnView.defaultCameraController.interactionMode = .orbitTurntable
+        scnView.preferredFramesPerSecond = 60
+
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        scnView.addGestureRecognizer(tap)
+        context.coordinator.scnView = scnView
+        scnView.scene = makeScene()
+        return scnView
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {
+        uiView.scene = makeScene()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selectedPlatformId: $selectedPlatformId)
+    }
+
+    private func makeScene() -> SCNScene {
+        let scene = SCNScene()
+
+        let camera = SCNNode()
+        camera.camera = SCNCamera()
+        camera.position = SCNVector3(0, 5, 8)
+        camera.look(at: SCNVector3(0, 0, 0))
+        scene.rootNode.addChildNode(camera)
+
+        let ambient = SCNNode()
+        ambient.light = SCNLight()
+        ambient.light?.type = .ambient
+        ambient.light?.intensity = 280
+        scene.rootNode.addChildNode(ambient)
+
+        let key = SCNNode()
+        key.light = SCNLight()
+        key.light?.type = .directional
+        key.light?.intensity = 950
+        key.eulerAngles = SCNVector3(-0.9, 0.4, 0)
+        scene.rootNode.addChildNode(key)
+
+        let water = SCNPlane(width: 12, height: 12)
+        let waterMaterial = SCNMaterial()
+        waterMaterial.diffuse.contents = UIColor.systemBlue.withAlphaComponent(0.25)
+        waterMaterial.isDoubleSided = true
+        water.materials = [waterMaterial]
+        let waterNode = SCNNode(geometry: water)
+        waterNode.eulerAngles = SCNVector3(-Float.pi / 2, 0, 0)
+        waterNode.position = SCNVector3(0, -0.05, 0)
+        scene.rootNode.addChildNode(waterNode)
+
+        let maxTotal = max(platforms.map(\.platformGamesTotal).max() ?? 1, 1)
+        let count = max(platforms.count, 1)
+
+        for (index, platform) in platforms.enumerated() {
+            let angle = Float(index) / Float(count) * Float.pi * 2
+            let radius: Float = 2.4
+            let x = cos(angle) * radius
+            let z = sin(angle) * radius
+            let height = max(0.35, Float(platform.platformGamesTotal) / Float(maxTotal) * 2.8)
+            let islandRadius = 0.35 + Float(platform.platformGamesTotal) / Float(maxTotal) * 0.35
+
+            let cylinder = SCNCylinder(radius: CGFloat(islandRadius), height: CGFloat(height))
+            let material = SCNMaterial()
+            material.diffuse.contents = palette[index % palette.count]
+            material.lightingModel = .physicallyBased
+            material.roughness.contents = 0.55
+            material.metalness.contents = 0.1
+            cylinder.materials = [material]
+
+            let node = SCNNode(geometry: cylinder)
+            node.position = SCNVector3(x, height / 2, z)
+            node.name = platform.id ?? platform.name
+            scene.rootNode.addChildNode(node)
+
+            // Soft physics-like idle sway
+            let sway = SCNAction.repeatForever(
+                .sequence([
+                    .moveBy(x: 0.04, y: 0, z: -0.03, duration: 1.4),
+                    .moveBy(x: -0.04, y: 0, z: 0.03, duration: 1.4)
+                ])
+            )
+            node.runAction(sway)
+        }
+
+        return scene
+    }
+
+    final class Coordinator: NSObject {
+        var selectedPlatformId: Binding<String?>
+        weak var scnView: SCNView?
+
+        init(selectedPlatformId: Binding<String?>) {
+            self.selectedPlatformId = selectedPlatformId
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scnView else { return }
+            let hits = scnView.hitTest(gesture.location(in: scnView), options: nil)
+            guard let name = hits.first?.node.name else { return }
+            selectedPlatformId.wrappedValue = name
+            hits.first?.node.runAction(.sequence([
+                .scale(to: 1.15, duration: 0.1),
+                .scale(to: 1.0, duration: 0.12)
+            ]))
+        }
+    }
+}
+#endif

--- a/GameNet/Presentation/Components/ThreeD/YearTimeline3DView.swift
+++ b/GameNet/Presentation/Components/ThreeD/YearTimeline3DView.swift
@@ -1,0 +1,210 @@
+//
+//  YearTimeline3DView.swift
+//  GameNet
+//
+//  Timeline 3D de totais anuais (finalizados/comprados), Metal via SceneKit.
+//
+
+import SceneKit
+import SwiftUI
+
+struct YearTimelineEntry: Identifiable, Hashable {
+    let year: Int
+    let primaryValue: Double
+    let secondaryLabel: String?
+
+    var id: Int { year }
+}
+
+struct YearTimeline3DView: View {
+    let title: String
+    let entries: [YearTimelineEntry]
+    var accentColor: Color = .main
+    var onSelectYear: (Int) -> Void
+
+    @State private var selectedYear: Int?
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.tertiaryCardBackground)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text(title)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.cardTitle)
+
+                #if os(iOS)
+                YearTimelineSceneView(
+                    entries: entries,
+                    accent: UIColor(accentColor),
+                    selectedYear: $selectedYear
+                )
+                .frame(height: 220)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                #else
+                Text("Visualização 3D disponível no iOS")
+                    .frame(height: 220)
+                #endif
+
+                if let selectedYear,
+                   let entry = entries.first(where: { $0.year == selectedYear }) {
+                    HStack {
+                        Text(String(entry.year))
+                            .font(.headline)
+                        Spacer()
+                        Text(formatted(entry.primaryValue))
+                            .font(.headline)
+                        if let secondary = entry.secondaryLabel {
+                            Text(secondary)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Button("Ver detalhes de \(entry.year)") {
+                        onSelectYear(entry.year)
+                    }
+                    .font(.footnote)
+                } else {
+                    Text("Gire • toque em um anel/coluna do ano")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding()
+        }
+        .padding()
+    }
+
+    private func formatted(_ value: Double) -> String {
+        if value == floor(value) {
+            return String(Int(value))
+        }
+        return String(format: "%.0f", value)
+    }
+}
+
+#if os(iOS)
+struct YearTimelineSceneView: UIViewRepresentable {
+    let entries: [YearTimelineEntry]
+    let accent: UIColor
+    @Binding var selectedYear: Int?
+
+    func makeUIView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        scnView.backgroundColor = .clear
+        scnView.isOpaque = false
+        scnView.antialiasingMode = .multisampling4X
+        scnView.autoenablesDefaultLighting = true
+        scnView.allowsCameraControl = true
+        scnView.defaultCameraController.interactionMode = .orbitTurntable
+        scnView.preferredFramesPerSecond = 60
+
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        scnView.addGestureRecognizer(tap)
+        context.coordinator.scnView = scnView
+        scnView.scene = makeScene()
+        return scnView
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {
+        uiView.scene = makeScene()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selectedYear: $selectedYear)
+    }
+
+    private func makeScene() -> SCNScene {
+        let scene = SCNScene()
+
+        let camera = SCNNode()
+        camera.camera = SCNCamera()
+        camera.position = SCNVector3(0, 3.5, 7)
+        camera.look(at: SCNVector3(0, 0.5, 0))
+        scene.rootNode.addChildNode(camera)
+
+        let ambient = SCNNode()
+        ambient.light = SCNLight()
+        ambient.light?.type = .ambient
+        ambient.light?.intensity = 320
+        scene.rootNode.addChildNode(ambient)
+
+        let key = SCNNode()
+        key.light = SCNLight()
+        key.light?.type = .directional
+        key.light?.intensity = 900
+        key.eulerAngles = SCNVector3(-0.7, 0.35, 0)
+        scene.rootNode.addChildNode(key)
+
+        let maxValue = max(entries.map(\.primaryValue).max() ?? 1, 1)
+        let sorted = entries.sorted { $0.year < $1.year }
+
+        for (index, entry) in sorted.enumerated() {
+            let z = Float(index) * 1.15 - Float(sorted.count - 1) * 0.575
+            let height = max(0.35, Float(entry.primaryValue / maxValue) * 2.4)
+            let radius: CGFloat = 0.45
+
+            let tube = SCNTube(innerRadius: radius * 0.55, outerRadius: radius, height: CGFloat(height))
+            let material = SCNMaterial()
+            material.diffuse.contents = accent.withAlphaComponent(0.85)
+            material.lightingModel = .physicallyBased
+            material.roughness.contents = 0.45
+            material.metalness.contents = 0.2
+            tube.materials = [material]
+
+            let node = SCNNode(geometry: tube)
+            node.position = SCNVector3(0, height / 2, z)
+            node.name = "year-\(entry.year)"
+            scene.rootNode.addChildNode(node)
+
+            let label = SCNText(string: String(entry.year), extrusionDepth: 0.02)
+            label.font = UIFont.systemFont(ofSize: 0.28, weight: .semibold)
+            label.flatness = 0.1
+            let labelNode = SCNNode(geometry: label)
+            labelNode.scale = SCNVector3(0.6, 0.6, 0.6)
+            labelNode.position = SCNVector3(-0.45, -0.15, z)
+            labelNode.name = "year-\(entry.year)"
+            scene.rootNode.addChildNode(labelNode)
+        }
+
+        let axis = SCNCylinder(radius: 0.02, height: CGFloat(max(sorted.count, 1)) * 1.2)
+        let axisMaterial = SCNMaterial()
+        axisMaterial.diffuse.contents = UIColor.white.withAlphaComponent(0.25)
+        axis.materials = [axisMaterial]
+        let axisNode = SCNNode(geometry: axis)
+        axisNode.eulerAngles = SCNVector3(Float.pi / 2, 0, 0)
+        axisNode.position = SCNVector3(0, 0.02, 0)
+        scene.rootNode.addChildNode(axisNode)
+
+        return scene
+    }
+
+    final class Coordinator: NSObject {
+        var selectedYear: Binding<Int?>
+        weak var scnView: SCNView?
+
+        init(selectedYear: Binding<Int?>) {
+            self.selectedYear = selectedYear
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scnView else { return }
+            let hits = scnView.hitTest(gesture.location(in: scnView), options: nil)
+            guard let name = hits.first?.node.name,
+                  name.hasPrefix("year-"),
+                  let year = Int(name.replacingOccurrences(of: "year-", with: "")) else {
+                return
+            }
+            selectedYear.wrappedValue = year
+            if let node = hits.first?.node {
+                node.runAction(.sequence([
+                    .scale(to: 1.12, duration: 0.1),
+                    .scale(to: 1.0, duration: 0.1)
+                ]))
+            }
+        }
+    }
+}
+#endif

--- a/GameNet/Presentation/Extensions/View+Extensions.swift
+++ b/GameNet/Presentation/Extensions/View+Extensions.swift
@@ -69,6 +69,10 @@ private struct GameDetailZoomTransitionModifier: ViewModifier {
             content
                 .gameDetailNavigationBar()
                 .navigationTransition(.zoom(sourceID: gameId, in: namespace))
+                // Continuidade espacial: o zoom 2D encontra a capa 3D no destino
+                .transaction { transaction in
+                    transaction.animation = transaction.animation ?? .smooth(duration: 0.45)
+                }
         } else {
             content
                 .gameDetailNavigationBar()

--- a/GameNet/Presentation/Features/Dashboard/View/AnnualGameplayProgressChartView.swift
+++ b/GameNet/Presentation/Features/Dashboard/View/AnnualGameplayProgressChartView.swift
@@ -15,8 +15,10 @@ struct AnnualGameplayProgressChartView: View {
     // MARK: Internal
 
     let series: [AnnualGameplayProgressSeries]
+    var onSelectYear: ((Int) -> Void)? = nil
     @State var selectedPoint: AnnualGameplayProgressPoint? = nil
     @State var scrollPosition = 1
+    @State private var shows3DSurface = false
 
     var body: some View {
         ZStack {
@@ -24,17 +26,34 @@ struct AnnualGameplayProgressChartView: View {
                 .fill(Color.primaryCardBackground)
 
             VStack(alignment: .leading, spacing: 16) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(title)
-                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)
-                        .font(.cardTitle)
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(title)
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)
+                            .font(.cardTitle)
 
-                    if let subtitle {
-                        Text(subtitle)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                        if let subtitle {
+                            Text(subtitle)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
                     }
 
+                    Picker("Modo", selection: $shows3DSurface) {
+                        Text("2D").tag(false)
+                        Text("3D").tag(true)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 100)
+                }
+
+                if shows3DSurface {
+                    AnnualGameplaySurface3DView(
+                        series: series,
+                        onSelectYear: onSelectYear
+                    )
+                    .frame(height: 320)
+                } else {
                     GeometryReader { _ in
                         Chart(gameplayPoints) { point in
                             LineMark(
@@ -125,8 +144,8 @@ struct AnnualGameplayProgressChartView: View {
                             scrollPosition = initialScrollPosition
                         }
                     }
+                    .frame(height: 300)
                 }
-                .frame(height: 300)
             }
             .padding()
         }

--- a/GameNet/Presentation/Features/Dashboard/View/DashboardView.swift
+++ b/GameNet/Presentation/Features/Dashboard/View/DashboardView.swift
@@ -414,34 +414,12 @@ extension DashboardView {
 
 extension DashboardView {
     var gamesByPlatformCard: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.tertiaryCardBackground)
-
-            VStack(alignment: .leading, spacing: 15) {
-                VStack {
-                    Text("Jogos por Plataforma")
-                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)
-                        .font(.cardTitle)
-                }
-
-                VStack(alignment: .leading, spacing: 5) {
-                    if let gamesByPlatform = viewModel.dashboard?.gamesByPlatform?.platforms {
-                        ForEach(gamesByPlatform, id: \.id) { gameByPlatform in
-                            HStack(spacing: 20) {
-                                Text(gameByPlatform.platformGamesTotal.toLeadingZerosString(decimalPlaces: 3))
-                                    .font(.dashboardGameTitle)
-                                Text(gameByPlatform.name)
-                                    .font(.dashboardGameTitle)
-                                Spacer()
-                            }
-                        }
-                    }
-                }
-            }
-            .padding()
-        }
-        .padding()
+        PlatformsIslands3DView(
+            platforms: viewModel.dashboard?.gamesByPlatform?.platforms ?? [],
+            total: viewModel.dashboard?.gamesByPlatform?.total
+                ?? viewModel.dashboard?.totalGames
+                ?? 0
+        )
     }
 }
 

--- a/GameNet/Presentation/Features/Dashboard/View/DashboardView.swift
+++ b/GameNet/Presentation/Features/Dashboard/View/DashboardView.swift
@@ -280,7 +280,12 @@ extension DashboardView {
 extension DashboardView {
     var annualGameplayProgressCard: some View {
         AnnualGameplayProgressChartView(
-            series: viewModel.annualGameplayProgress
+            series: viewModel.annualGameplayProgress,
+            onSelectYear: { year in
+                if let sessions = viewModel.gameplaySessions?[year] {
+                    presentedViews.append(GameplaySessionNavigation(key: year, value: sessions))
+                }
+            }
         )
     }
 }

--- a/GameNet/Presentation/Features/Dashboard/View/DashboardView.swift
+++ b/GameNet/Presentation/Features/Dashboard/View/DashboardView.swift
@@ -327,10 +327,19 @@ extension DashboardView {
 
 extension DashboardView {
     var finishedByYearTimelineCard: some View {
-        FinishedByYearTimelineView(
-            finishedGamesByYear: viewModel.dashboard?.finishedByYear ?? [],
-            onYearTapped: { finishedGame in
-                presentedViews.append(finishedGame)
+        YearTimeline3DView(
+            title: "Finalizados por Ano",
+            entries: (viewModel.dashboard?.finishedByYear ?? []).map {
+                YearTimelineEntry(
+                    year: $0.year,
+                    primaryValue: Double($0.total),
+                    secondaryLabel: $0.total == 1 ? "jogo" : "jogos"
+                )
+            },
+            onSelectYear: { year in
+                if let finished = viewModel.dashboard?.finishedByYear?.first(where: { $0.year == year }) {
+                    presentedViews.append(finished)
+                }
             }
         )
     }
@@ -384,48 +393,22 @@ extension DashboardView {
 
 extension DashboardView {
     var boughtByYearCard: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.tertiaryCardBackground)
-
-            VStack(alignment: .leading, spacing: 15) {
-                VStack {
-                    Text("Comprados por Ano")
-                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)
-                        .font(.cardTitle)
-                }
-
-                VStack(alignment: .leading) {
-                    VStack(alignment: .leading) {
-                        if let boughtByYear = viewModel.dashboard?.boughtByYear {
-                            ForEach(boughtByYear, id: \.year) { boughtGame in
-                                SwiftUI.NavigationLink(value: boughtGame) {
-                                    HStack(spacing: 20) {
-                                        Text(
-                                            boughtGame.quantity
-                                                .toLeadingZerosString(decimalPlaces: 2)
-                                        )
-                                        .font(.dashboardGameTitle)
-
-                                        Text(String(boughtGame.year))
-                                            .font(.dashboardGameTitle)
-
-                                        Spacer()
-                                        
-                                        if let formattedTotalPrice = boughtGame.total.toCurrencyString() {
-                                            Text(String("\(formattedTotalPrice)"))
-                                                .font(.dashboardGameTitle)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+        YearTimeline3DView(
+            title: "Comprados por Ano",
+            entries: (viewModel.dashboard?.boughtByYear ?? []).map {
+                YearTimelineEntry(
+                    year: $0.year,
+                    primaryValue: Double($0.quantity),
+                    secondaryLabel: $0.total.toCurrencyString()
+                )
+            },
+            accentColor: .orange,
+            onSelectYear: { year in
+                if let bought = viewModel.dashboard?.boughtByYear?.first(where: { $0.year == year }) {
+                    presentedViews.append(bought)
                 }
             }
-            .padding()
-        }
-        .padding()
+        )
     }
 }
 

--- a/GameNet/Presentation/Features/Dashboard/View/GameCoverView.swift
+++ b/GameNet/Presentation/Features/Dashboard/View/GameCoverView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
 
 private enum GameCoverAction: Identifiable {
     case toggle
@@ -39,19 +38,10 @@ struct GameCoverView: View {
         SwiftUI.NavigationLink(value: viewModel.playingGame) {
             VStack(alignment: .center) {
                 ZStack(alignment: .bottomTrailing) {
-                    
-                CachedAsyncImage(url: URL(string: coverURL)) { phase in
-                    switch phase {
-                    case .success(let image):
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                    default:
-                        coverImageSkeleton
-                    }
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .gameCoverTransitionSource(id: viewModel.playingGame.id)
+                GameCover3DView(coverURL: coverURL, cornerRadius: 12, enablesMotion: true)
+                    .aspectRatio(2 / 3, contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                    .gameCoverTransitionSource(id: viewModel.playingGame.id)
                     if FirebaseRemoteConfig.toggleGameplaySession {
                         Button {
                             activeAction = .toggle
@@ -152,14 +142,6 @@ struct GameCoverView: View {
             coverAccentColor = await CoverAccentColor.from(urlString: coverURL)
             #endif
         }
-    }
-
-    private var coverImageSkeleton: some View {
-        RoundedRectangle(cornerRadius: 12)
-            .fill(Color.secondary.opacity(0.2))
-            .aspectRatio(2 / 3, contentMode: .fit)
-            .frame(maxWidth: .infinity)
-            .redacted(reason: .placeholder)
     }
 }
 

--- a/GameNet/Presentation/Features/Games/Model/GameDetailState.swift
+++ b/GameNet/Presentation/Features/Games/Model/GameDetailState.swift
@@ -18,6 +18,8 @@ struct GameDetailRoute: Hashable {
     let preview: GameDetailPreview
 }
 
+struct SpatialLibraryRoute: Hashable {}
+
 extension GameDetailPreview {
     init(playingGame: PlayingGame) {
         coverURL = playingGame.coverURL

--- a/GameNet/Presentation/Features/Games/View/GameDetailView.swift
+++ b/GameNet/Presentation/Features/Games/View/GameDetailView.swift
@@ -143,7 +143,8 @@ struct GameDetailView: View {
             GameCover3DView(
                 coverURL: displayCoverURL,
                 cornerRadius: 12,
-                enablesMotion: true
+                enablesMotion: true,
+                playsEntranceTransition: true
             )
             .frame(height: 250)
             .shadow(color: .black.opacity(0.35), radius: 16, y: 8)

--- a/GameNet/Presentation/Features/Games/View/GameDetailView.swift
+++ b/GameNet/Presentation/Features/Games/View/GameDetailView.swift
@@ -140,17 +140,11 @@ struct GameDetailView: View {
 
     private var heroCoverSection: some View {
         ZStack(alignment: .bottomTrailing) {
-            CachedAsyncImage(url: URL(string: displayCoverURL)) { phase in
-                switch phase {
-                case .success(let image):
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                default:
-                    coverImageSkeleton
-                }
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+            GameCover3DView(
+                coverURL: displayCoverURL,
+                cornerRadius: 12,
+                enablesMotion: true
+            )
             .frame(height: 250)
             .shadow(color: .black.opacity(0.35), radius: 16, y: 8)
             .onTapGesture(count: 2) {

--- a/GameNet/Presentation/Features/Games/View/GameDetailView.swift
+++ b/GameNet/Presentation/Features/Games/View/GameDetailView.swift
@@ -249,6 +249,13 @@ struct GameDetailView: View {
                 sessionsSummaryRow(totalGameplayTime: gameplays.totalGameplayTime)
 
                 if !viewModel.sortedGameplaySessions.isEmpty {
+                    GameplaySessionsMap3DView(
+                        sessions: viewModel.sortedGameplaySessions,
+                        accentColor: coverAccentColor,
+                        isActiveSession: { $0.finish == nil }
+                    )
+                    .padding(.top, 4)
+
                     sessionsHistoryExpander
                 }
             }

--- a/GameNet/Presentation/Features/Games/View/GameItemView.swift
+++ b/GameNet/Presentation/Features/Games/View/GameItemView.swift
@@ -5,7 +5,6 @@
 //  Created by Alliston Aleixo on 25/07/23.
 //
 
-import CachedAsyncImage
 import Factory
 import SwiftUI
 
@@ -18,13 +17,15 @@ struct GameItemView: View {
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
-            CachedAsyncImage(url: URL(string: coverURL)) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-            } placeholder: { ProgressView().progressViewStyle(.circular) }
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+            GameCover3DView(
+                coverURL: coverURL,
+                cornerRadius: 8,
+                enablesMotion: false,
+                autoRotate: true
+            )
+            .aspectRatio(2 / 3, contentMode: .fit)
             .gameCoverTransitionSource(id: gameId)
+
             Text(name)
                 .padding(4)
                 .foregroundColor(.white)

--- a/GameNet/Presentation/Features/Games/View/GamesView.swift
+++ b/GameNet/Presentation/Features/Games/View/GamesView.swift
@@ -72,6 +72,22 @@ struct GamesView: View {
                     )
                     .gameDetailZoomTransition(gameId: route.id)
                 }
+                .navigationDestination(for: SpatialLibraryRoute.self) { _ in
+                    SpatialLibraryView(
+                        games: spatialLibraryItems
+                    ) { item in
+                        presentedGames.append(
+                            GameDetailRoute(
+                                id: item.id,
+                                preview: GameDetailPreview(
+                                    coverURL: item.coverURL,
+                                    name: item.name,
+                                    platform: item.platform
+                                )
+                            )
+                        )
+                    }
+                }
                 .searchable(
                     text: $search,
                     prompt: Text("Buscar")
@@ -96,6 +112,12 @@ struct GamesView: View {
             .navigationView(title: "Games")
             .toolbar {
                 if origin == .home {
+                    Button(action: {}) {
+                        SwiftUI.NavigationLink(value: SpatialLibraryRoute()) {
+                            Image(systemName: "square.stack.3d.up")
+                        }
+                    }
+
                     Button(action: {}) {
                         SwiftUI.NavigationLink {
                             viewModel.showGameEditView(
@@ -136,6 +158,19 @@ struct GamesView: View {
     ]
 
     @State var presentedGames = NavigationPath()
+
+    private var spatialLibraryItems: [SpatialLibraryItem] {
+        let source = search.isEmpty ? viewModel.data : viewModel.searchedGames
+        return source.compactMap { game in
+            guard let id = game.id else { return nil }
+            return SpatialLibraryItem(
+                id: id,
+                name: game.name,
+                coverURL: game.coverURL ?? "",
+                platform: game.platform ?? ""
+            )
+        }
+    }
 }
 
 // MARK: - Previews

--- a/GameNet/Presentation/Features/Games/View/SpatialLibrary/SpatialLibraryView.swift
+++ b/GameNet/Presentation/Features/Games/View/SpatialLibrary/SpatialLibraryView.swift
@@ -1,0 +1,223 @@
+//
+//  SpatialLibraryView.swift
+//  GameNet
+//
+//  Galeria espacial 3D da biblioteca: capas como tiles navegáveis
+//  em profundidade, acelerada por Metal via SceneKit.
+//
+
+import SceneKit
+import SwiftUI
+
+// MARK: - SpatialLibraryItem
+
+struct SpatialLibraryItem: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let coverURL: String
+    let platform: String
+}
+
+// MARK: - SpatialLibraryView
+
+struct SpatialLibraryView: View {
+    let games: [SpatialLibraryItem]
+    var onSelect: (SpatialLibraryItem) -> Void
+
+    @State private var selectedPlatform: String = "Todas"
+    @State private var selectedItemId: String?
+
+    private var platforms: [String] {
+        let names = Set(games.map(\.platform).filter { !$0.isEmpty })
+        return ["Todas"] + names.sorted()
+    }
+
+    private var filteredGames: [SpatialLibraryItem] {
+        if selectedPlatform == "Todas" {
+            return games
+        }
+        return games.filter { $0.platform == selectedPlatform }
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Picker("Plataforma", selection: $selectedPlatform) {
+                ForEach(platforms, id: \.self) { platform in
+                    Text(platform).tag(platform)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
+
+            #if os(iOS)
+            SpatialLibrarySceneView(
+                games: filteredGames,
+                selectedItemId: $selectedItemId
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .padding(.horizontal)
+            #else
+            Text("Visualização 3D disponível no iOS")
+                .foregroundStyle(.secondary)
+            #endif
+
+            if let selected = filteredGames.first(where: { $0.id == selectedItemId }) {
+                VStack(spacing: 8) {
+                    Text(selected.name)
+                        .font(.headline)
+                        .multilineTextAlignment(.center)
+                    Text(selected.platform)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Button("Abrir detalhes") {
+                        onSelect(selected)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding(.bottom)
+            } else {
+                Text("Arraste para explorar • toque em uma capa")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom)
+            }
+        }
+        .navigationTitle("Prateleira 3D")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+}
+
+// MARK: - SceneKit view
+
+#if os(iOS)
+struct SpatialLibrarySceneView: UIViewRepresentable {
+    let games: [SpatialLibraryItem]
+    @Binding var selectedItemId: String?
+
+    func makeUIView(context: Context) -> SCNView {
+        let scnView = SCNView()
+        scnView.backgroundColor = .clear
+        scnView.isOpaque = false
+        scnView.antialiasingMode = .multisampling4X
+        scnView.autoenablesDefaultLighting = true
+        scnView.allowsCameraControl = true
+        scnView.defaultCameraController.interactionMode = .orbitTurntable
+        scnView.defaultCameraController.maximumVerticalAngle = 45
+        scnView.defaultCameraController.minimumVerticalAngle = -10
+        scnView.preferredFramesPerSecond = 60
+
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        scnView.addGestureRecognizer(tap)
+        context.coordinator.scnView = scnView
+
+        scnView.scene = makeScene(games: games, coordinator: context.coordinator)
+        return scnView
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {
+        uiView.scene = makeScene(games: games, coordinator: context.coordinator)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selectedItemId: $selectedItemId)
+    }
+
+    private func makeScene(games: [SpatialLibraryItem], coordinator: Coordinator) -> SCNScene {
+        let scene = SCNScene()
+
+        let cameraNode = SCNNode()
+        cameraNode.camera = SCNCamera()
+        cameraNode.camera?.wantsHDR = true
+        cameraNode.position = SCNVector3(0, 1.2, 6)
+        cameraNode.look(at: SCNVector3(0, 0, 0))
+        scene.rootNode.addChildNode(cameraNode)
+
+        let ambient = SCNNode()
+        ambient.light = SCNLight()
+        ambient.light?.type = .ambient
+        ambient.light?.intensity = 350
+        scene.rootNode.addChildNode(ambient)
+
+        let key = SCNNode()
+        key.light = SCNLight()
+        key.light?.type = .directional
+        key.light?.intensity = 900
+        key.eulerAngles = SCNVector3(-0.8, 0.3, 0)
+        scene.rootNode.addChildNode(key)
+
+        let columns = 5
+        let spacingX: Float = 1.35
+        let spacingZ: Float = 1.7
+        let rows = max(1, Int(ceil(Double(games.count) / Double(columns))))
+
+        for (index, game) in games.enumerated() {
+            let row = index / columns
+            let col = index % columns
+            let x = Float(col) * spacingX - Float(columns - 1) * spacingX / 2
+            let z = -Float(row) * spacingZ
+
+            let plane = SCNPlane(width: 1.0, height: 1.45)
+            plane.cornerRadius = 0.06
+            let material = SCNMaterial()
+            material.diffuse.contents = UIColor.secondarySystemFill
+            material.lightingModel = .physicallyBased
+            material.roughness.contents = 0.6
+            plane.materials = [material]
+
+            let node = SCNNode(geometry: plane)
+            node.name = game.id
+            node.position = SCNVector3(x, 0, z)
+            scene.rootNode.addChildNode(node)
+
+            Task { @MainActor in
+                if let image = await CoverImageLoader.image(from: game.coverURL) {
+                    material.diffuse.contents = image
+                }
+            }
+        }
+
+        // Floor shelf
+        let floor = SCNFloor()
+        floor.reflectivity = 0.05
+        let floorMaterial = SCNMaterial()
+        floorMaterial.diffuse.contents = UIColor(white: 0.12, alpha: 1)
+        floor.materials = [floorMaterial]
+        let floorNode = SCNNode(geometry: floor)
+        floorNode.position = SCNVector3(0, -0.8, -Float(rows) * spacingZ / 2)
+        scene.rootNode.addChildNode(floorNode)
+
+        coordinator.itemIds = Set(games.map(\.id))
+        return scene
+    }
+
+    final class Coordinator: NSObject {
+        var selectedItemId: Binding<String?>
+        weak var scnView: SCNView?
+        var itemIds: Set<String> = []
+
+        init(selectedItemId: Binding<String?>) {
+            self.selectedItemId = selectedItemId
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scnView else { return }
+            let location = gesture.location(in: scnView)
+            let hits = scnView.hitTest(location, options: [.searchMode: SCNHitTestSearchMode.closest.rawValue])
+            guard let name = hits.first?.node.name, itemIds.contains(name) else { return }
+            selectedItemId.wrappedValue = name
+
+            if let node = hits.first?.node {
+                let pulse = SCNAction.sequence([
+                    SCNAction.scale(to: 1.12, duration: 0.12),
+                    SCNAction.scale(to: 1.0, duration: 0.12)
+                ])
+                node.runAction(pulse)
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Introduz elementos 3D úteis no GameNet, renderizados com SceneKit (Metal), em 7 commits de feature (+ 1 fix de wiring):

1. **Capas 3D** — caixa/cartucho texturizado com parallax no carrossel, grid e hero do detalhe
2. **Galeria espacial** — prateleira 3D da biblioteca (toolbar em Games)
3. **Superfície de progresso anual** — toggle 2D/3D no card de evolução
4. **Timeline 3D** — finalizados e comprados por ano como anéis em profundidade
5. **Mapa de sessões** — blocos 3D por duração no detalhe do jogo
6. **Ilhas por plataforma** — volume proporcional à quantidade de jogos
7. **Transição capa → detalhe** — lift/turn SceneKit + zoom navigation

## Notas

- Aceleração de hardware via SceneKit/Metal
- Fallback textual em plataformas não-iOS onde aplicável
- Sem Live Activities / widget 3D (item 8 ficou de fora, conforme pedido; Live Activities estão em PR separado)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa435-5999-7596-af41-ea2d3b7f02cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa435-5999-7596-af41-ea2d3b7f02cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

