### PR TITLE
Feat: redesign das listas com cards de capas

### DIFF
--- a/GameNet/DataProvider/Cache/CoverImageCache.swift
+++ b/GameNet/DataProvider/Cache/CoverImageCache.swift
@@ -1,0 +1,72 @@
+//
+//  CoverImageCache.swift
+//  GameNet
+//
+//  Created by Alliston Aleixo on 14/08/26.
+//
+
+import Foundation
+
+enum CoverImageCache {
+    static let urlCache: URLCache = {
+        let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("CoverImages", isDirectory: true)
+
+        return URLCache(
+            memoryCapacity: 64 * 1_024 * 1_024,
+            diskCapacity: 256 * 1_024 * 1_024,
+            directory: directory
+        )
+    }()
+
+    static func request(for urlString: String) -> URLRequest? {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let url = URL(string: trimmed) else { return nil }
+        return URLRequest(url: url)
+    }
+
+    static func prefetch(urls: [String]) {
+        let uniqueURLs = Array(Set(urls))
+        guard !uniqueURLs.isEmpty else { return }
+
+        Task.detached(priority: .utility) {
+            await withTaskGroup(of: Void.self) { group in
+                for urlString in uniqueURLs {
+                    group.addTask {
+                        await downloadIfNeeded(urlString)
+                    }
+                }
+            }
+        }
+    }
+
+    static func cachedData(for urlString: String) -> Data? {
+        guard let request = request(for: urlString) else { return nil }
+        return urlCache.cachedResponse(for: request)?.data
+    }
+
+    static func store(data: Data, response: URLResponse, for urlString: String) {
+        guard let request = request(for: urlString) else { return }
+        urlCache.storeCachedResponse(CachedURLResponse(response: response, data: data), for: request)
+    }
+
+    private static func downloadIfNeeded(_ urlString: String) async {
+        guard let request = request(for: urlString) else { return }
+        if urlCache.cachedResponse(for: request) != nil {
+            return
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200...299).contains(httpResponse.statusCode) {
+                return
+            }
+
+            store(data: data, response: response, for: urlString)
+        } catch {
+            return
+        }
+    }
+}

--- a/GameNet/DataProvider/DataSources/List/ListDataSource.swift
+++ b/GameNet/DataProvider/DataSources/List/ListDataSource.swift
@@ -11,10 +11,16 @@ import Foundation
 
 protocol ListDataSourceProtocol {
     func fetchData(cache: Bool) async -> [List]?
-    func fetchData(id: String) async -> ListGame?
+    func fetchData(id: String, cache: Bool) async -> ListGame?
     func fetchFinishedByYearData(id: Int) async -> [ListItem]?
     func fetchBoughtByYearData(id: Int) async -> [ListItem]?
     func saveList(id: String?, userId: String?, list: ListGame) async -> List?
+}
+
+extension ListDataSourceProtocol {
+    func fetchData(id: String) async -> ListGame? {
+        await fetchData(id: id, cache: true)
+    }
 }
 
 // MARK: - ListDataSource
@@ -37,11 +43,12 @@ class ListDataSource: ListDataSourceProtocol {
         return nil
     }
 
-    func fetchData(id: String) async -> ListGame? {
+    func fetchData(id: String, cache: Bool = true) async -> ListGame? {
         if let apiResult = await NetworkManager.shared
             .performRequest(
                 responseType: APIResult<ListGameResponseDTO>.self,
-                endpoint: .list(id: id)
+                endpoint: .list(id: id),
+                cache: cache
             ) {
             if apiResult.ok {
                 return apiResult.data.toListGame()

--- a/GameNet/DataProvider/DataSources/List/MockListDataSource.swift
+++ b/GameNet/DataProvider/DataSources/List/MockListDataSource.swift
@@ -20,7 +20,7 @@ class MockListDataSource: ListDataSourceProtocol {
         return MockListDataSource.lists
     }
 
-    func fetchData(id: String) async -> ListGame? {
+    func fetchData(id: String, cache: Bool = true) async -> ListGame? {
         MockListDataSource.listsGames.first { list in
             list.id == id
         }

--- a/GameNet/DataProvider/Repositories/List/ListRepository.swift
+++ b/GameNet/DataProvider/Repositories/List/ListRepository.swift
@@ -12,10 +12,16 @@ import Foundation
 
 protocol ListRepositoryProtocol {
     func fetchData(cache: Bool) async -> [List]?
-    func fetchData(id: String) async -> ListGame?
+    func fetchData(id: String, cache: Bool) async -> ListGame?
     func fetchFinishedByYearData(id: Int) async -> [ListItem]?
     func fetchBoughtByYearData(id: Int) async -> [ListItem]?
     func saveList(id: String?, userId: String?, list: ListGame) async -> List?
+}
+
+extension ListRepositoryProtocol {
+    func fetchData(id: String) async -> ListGame? {
+        await fetchData(id: id, cache: true)
+    }
 }
 
 // MARK: - ListRepository
@@ -28,8 +34,8 @@ struct ListRepository: ListRepositoryProtocol {
         return await dataSource.fetchData(cache: cache)
     }
 
-    func fetchData(id: String) async -> ListGame? {
-        return await dataSource.fetchData(id: id)
+    func fetchData(id: String, cache: Bool = true) async -> ListGame? {
+        return await dataSource.fetchData(id: id, cache: cache)
     }
     
     func fetchFinishedByYearData(id: Int) async -> [ListItem]? {

--- a/GameNet/DataProvider/Repositories/List/MockListRepository.swift
+++ b/GameNet/DataProvider/Repositories/List/MockListRepository.swift
@@ -20,7 +20,7 @@ struct MockListRepository: ListRepositoryProtocol {
         return MockListRepository.lists
     }
 
-    func fetchData(id: String) -> ListGame? {
+    func fetchData(id: String, cache: Bool = true) -> ListGame? {
         MockListRepository.listGames.first { list in
             list.id == id
         }

--- a/GameNet/DataProvider/Repositories/List/MockListRepository.swift
+++ b/GameNet/DataProvider/Repositories/List/MockListRepository.swift
@@ -59,37 +59,51 @@ struct MockListRepository: ListRepositoryProtocol {
                 id: "1",
                 name: "Lista Padrão",
                 games: [
-                    ListItem(
-                        id: "1",
-                        name: "The Legend of Zelda: Tears of the Kingdom",
-                        platform: "Nintendo Switch",
-                        userGameId: "123",
-                        year: 2023,
-                        boughtDate: nil,
-                        value: 0,
-                        start: nil,
-                        finish: nil,
-                        cover: "https://images.nintendolife.com/da314926e706f/switch-tloz-totk-boxart-011.large.jpg",
-                        order: 1,
-                        comment: "No comment"
-                    ),
-                    ListItem(
-                        id: "2",
+                    item(id: "1", name: "The Legend of Zelda: Tears of the Kingdom", userGameId: "123", order: 1),
+                    item(id: "2", name: "The Legend of Zelda: Breath of the Wild", userGameId: "456", order: 2),
+                    item(id: "3", name: "Super Mario Odyssey", userGameId: "789", order: 3),
+                    item(id: "4", name: "Kirby and the Forgotten Land", userGameId: "101", order: 4),
+                    item(id: "5", name: "Splatoon 3", userGameId: "112", order: 5)
+                ]
+            ),
+            ListGame(
+                id: "2",
+                name: "Melhores Zeldas",
+                games: [
+                    item(
+                        id: "6",
                         name: "The Legend of Zelda: Breath of the Wild",
-                        platform: "Nintendo Switch",
                         userGameId: "456",
-                        year: 2023,
-                        boughtDate: nil,
-                        value: 0,
-                        start: nil,
-                        finish: nil,
                         cover: "https://assets.reedpopcdn.com/148430785862.jpg/BROK/resize/1920x1920%3E/format/jpg/quality/80/148430785862.jpg",
-                        order: 2,
-                        comment: "No comment"
-                    )
+                        order: 1
+                    ),
+                    item(id: "7", name: "The Legend of Zelda: Tears of the Kingdom", userGameId: "123", order: 2)
                 ]
             )
         ]
+
+        static func item(
+            id: String,
+            name: String,
+            userGameId: String,
+            cover: String = "https://images.nintendolife.com/da314926e706f/switch-tloz-totk-boxart-011.large.jpg",
+            order: Int
+        ) -> ListItem {
+            ListItem(
+                id: id,
+                name: name,
+                platform: "Nintendo Switch",
+                userGameId: userGameId,
+                year: 2023,
+                boughtDate: nil,
+                value: 0,
+                start: nil,
+                finish: nil,
+                cover: cover,
+                order: order,
+                comment: "No comment"
+            )
+        }
     }
 
     private static var lists = Defaults.lists

--- a/GameNet/Presentation/Extensions/Font.swift
+++ b/GameNet/Presentation/Extensions/Font.swift
@@ -14,4 +14,6 @@ extension Font {
     static let listItemCellGameName = Font.custom("AvenirNext-DemiBold", size: 24)
     static let listItemCellPlatform = Font.custom("AvenirNext-DemiBold", size: 18)
     static let listItemCellDetail = Font.custom("AvenirNext-Regular", size: 16)
+    static let listCardTitle = Font.custom("AvenirNext-DemiBold", size: 20)
+    static let listCardOverflow = Font.custom("AvenirNext-DemiBold", size: 22)
 }

--- a/GameNet/Presentation/Features/Lists/Model/ListCardModel.swift
+++ b/GameNet/Presentation/Features/Lists/Model/ListCardModel.swift
@@ -1,0 +1,27 @@
+//
+//  ListCardModel.swift
+//  GameNet
+//
+//  Created by Alliston Aleixo on 14/08/26.
+//
+
+import Foundation
+
+struct ListCardModel: Identifiable, Equatable, Hashable {
+    let list: GameNet.List
+    var games: [ListItem]
+
+    var id: String { list.id ?? list.name }
+    var name: String { list.name }
+
+    var previewGames: [ListItem] {
+        Array(games.prefix(Self.previewLimit))
+    }
+
+    var overflowCount: Int? {
+        guard games.count > Self.previewLimit else { return nil }
+        return games.count - 2
+    }
+
+    private static let previewLimit = 3
+}

--- a/GameNet/Presentation/Features/Lists/View/ListCardView.swift
+++ b/GameNet/Presentation/Features/Lists/View/ListCardView.swift
@@ -85,7 +85,10 @@ struct ListCardView: View {
 
     private func coverSlice(coverURL: String?, showsOverflow: Bool) -> some View {
         GeometryReader { geometry in
-            CachedAsyncImage(url: URL(string: coverURL ?? "")) { phase in
+            CachedAsyncImage(
+                url: URL(string: coverURL ?? ""),
+                urlCache: CoverImageCache.urlCache
+            ) { phase in
                 switch phase {
                 case .success(let image):
                     image

--- a/GameNet/Presentation/Features/Lists/View/ListCardView.swift
+++ b/GameNet/Presentation/Features/Lists/View/ListCardView.swift
@@ -1,0 +1,129 @@
+//
+//  ListCardView.swift
+//  GameNet
+//
+//  Created by Alliston Aleixo on 14/08/26.
+//
+
+import CachedAsyncImage
+import SwiftUI
+
+struct ListCardView: View {
+    let model: ListCardModel
+
+    private let cardHeight: CGFloat = 96
+    private let accentBarWidth: CGFloat = 5
+    private let cornerRadius: CGFloat = 16
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Color.main
+                .frame(width: accentBarWidth)
+
+            ZStack(alignment: .leading) {
+                coverStrip
+
+                titleFade
+
+                GeometryReader { geometry in
+                    Text(model.name)
+                        .font(.listCardTitle)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .minimumScaleFactor(0.85)
+                        .shadow(color: .black.opacity(0.45), radius: 4, y: 1)
+                        .padding(.leading, 14)
+                        .frame(width: geometry.size.width * 0.58, alignment: .leading)
+                        .frame(maxHeight: .infinity, alignment: .center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: cardHeight)
+        .background(Color.primaryCardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .shadow(color: .black.opacity(0.22), radius: 8, y: 3)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(model.name)
+        .accessibilityValue(accessibilityValue)
+        .accessibilityAddTraits(.isButton)
+    }
+
+    @ViewBuilder
+    private var coverStrip: some View {
+        if model.previewGames.isEmpty {
+            Color.primaryCardBackground
+        } else {
+            HStack(spacing: 0) {
+                ForEach(Array(model.previewGames.enumerated()), id: \.offset) { index, game in
+                    coverSlice(
+                        coverURL: game.cover,
+                        showsOverflow: shouldShowOverflow(at: index)
+                    )
+                }
+            }
+        }
+    }
+
+    private var titleFade: some View {
+        LinearGradient(
+            stops: [
+                .init(color: Color.primaryCardBackground, location: 0),
+                .init(color: Color.primaryCardBackground.opacity(0.92), location: 0.22),
+                .init(color: Color.primaryCardBackground.opacity(0.62), location: 0.46),
+                .init(color: Color.primaryCardBackground.opacity(0.22), location: 0.7),
+                .init(color: .clear, location: 1)
+            ],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        .allowsHitTesting(false)
+    }
+
+    private func coverSlice(coverURL: String?, showsOverflow: Bool) -> some View {
+        GeometryReader { geometry in
+            CachedAsyncImage(url: URL(string: coverURL ?? "")) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .scaleEffect(1.14)
+                        .blur(radius: showsOverflow ? 8 : 0)
+                default:
+                    Color.primaryCardBackground.opacity(0.65)
+                }
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+            .clipped()
+            .overlay {
+                if showsOverflow, let overflowCount = model.overflowCount {
+                    ZStack {
+                        Color.black.opacity(0.48)
+                        Text("+\(overflowCount)")
+                            .font(.listCardOverflow)
+                            .foregroundStyle(.white)
+                            .shadow(color: .black.opacity(0.6), radius: 2, y: 1)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func shouldShowOverflow(at index: Int) -> Bool {
+        index == model.previewGames.count - 1 && model.overflowCount != nil
+    }
+
+    private var accessibilityValue: String {
+        let count = model.games.count
+        if count == 0 {
+            return "Lista vazia"
+        }
+        return count == 1 ? "1 jogo" : "\(count) jogos"
+    }
+}

--- a/GameNet/Presentation/Features/Lists/View/ListsView.swift
+++ b/GameNet/Presentation/Features/Lists/View/ListsView.swift
@@ -20,10 +20,21 @@ struct ListsView: View {
 
     var body: some View {
         NavigationStack(path: $presentedLists) {
-            VStack {
-                if let lists = viewModel.lists {
-                    SwiftUI.List(lists, id: \.id) { list in
-                        SwiftUI.NavigationLink(list.name, value: list.id)
+            GeometryReader { geometry in
+                ScrollView {
+                    if !viewModel.listCards.isEmpty {
+                        LazyVStack(spacing: 12) {
+                            ForEach(viewModel.listCards) { card in
+                                SwiftUI.NavigationLink(value: card.list.id ?? "") {
+                                    ListCardView(model: card)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .frame(maxWidth: PlatformMetrics.contentMaxWidth(for: geometry.size.width))
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, PlatformMetrics.horizontalPadding(for: geometry.size.width))
+                        .padding(.vertical, 8)
                     }
                 }
             }

--- a/GameNet/Presentation/Features/Lists/ViewModel/ListsViewModel.swift
+++ b/GameNet/Presentation/Features/Lists/ViewModel/ListsViewModel.swift
@@ -45,7 +45,7 @@ class ListsViewModel: ObservableObject {
             lists = result
             listCards = result.map { ListCardModel(list: $0, games: []) }
             state = .success(result)
-            await fetchListPreviews(for: result)
+            await fetchListPreviews(for: result, cache: cache)
         } else {
             state = .error("Erro no carregamento de dados do servidor")
         }
@@ -56,13 +56,13 @@ class ListsViewModel: ObservableObject {
     @Injected(\.listRepository) private var repository
     private var cancellable = Set<AnyCancellable>()
 
-    private func fetchListPreviews(for lists: [GameNet.List]) async {
+    private func fetchListPreviews(for lists: [GameNet.List], cache: Bool) async {
         await withTaskGroup(of: (String, [ListItem]).self) { group in
             for list in lists {
                 guard let id = list.id else { continue }
 
                 group.addTask {
-                    let games = await self.repository.fetchData(id: id)?.games ?? []
+                    let games = await self.repository.fetchData(id: id, cache: cache)?.games ?? []
                     let orderedGames = games.sorted { ($0.order ?? 0) < ($1.order ?? 0) }
                     return (id, orderedGames)
                 }
@@ -72,6 +72,10 @@ class ListsViewModel: ObservableObject {
                 if let index = listCards.firstIndex(where: { $0.list.id == id }) {
                     listCards[index].games = games
                 }
+
+                CoverImageCache.prefetch(
+                    urls: games.prefix(3).compactMap(\.cover)
+                )
             }
         }
     }

--- a/GameNet/Presentation/Features/Lists/ViewModel/ListsViewModel.swift
+++ b/GameNet/Presentation/Features/Lists/ViewModel/ListsViewModel.swift
@@ -10,7 +10,7 @@ import Factory
 import Foundation
 import SwiftUI
 
-// MARK: - PlatformsViewModel
+// MARK: - ListsViewModel
 
 @MainActor
 class ListsViewModel: ObservableObject {
@@ -33,6 +33,7 @@ class ListsViewModel: ObservableObject {
     // MARK: Internal
 
     @Published var lists: [GameNet.List]? = nil
+    @Published var listCards: [ListCardModel] = []
     @Published var state: ListsState = .idle
 
     func fetchData(cache: Bool = true) async {
@@ -41,7 +42,10 @@ class ListsViewModel: ObservableObject {
         let result = await repository.fetchData(cache: cache)
 
         if let result {
+            lists = result
+            listCards = result.map { ListCardModel(list: $0, games: []) }
             state = .success(result)
+            await fetchListPreviews(for: result)
         } else {
             state = .error("Erro no carregamento de dados do servidor")
         }
@@ -51,6 +55,26 @@ class ListsViewModel: ObservableObject {
 
     @Injected(\.listRepository) private var repository
     private var cancellable = Set<AnyCancellable>()
+
+    private func fetchListPreviews(for lists: [GameNet.List]) async {
+        await withTaskGroup(of: (String, [ListItem]).self) { group in
+            for list in lists {
+                guard let id = list.id else { continue }
+
+                group.addTask {
+                    let games = await self.repository.fetchData(id: id)?.games ?? []
+                    let orderedGames = games.sorted { ($0.order ?? 0) < ($1.order ?? 0) }
+                    return (id, orderedGames)
+                }
+            }
+
+            for await (id, games) in group {
+                if let index = listCards.firstIndex(where: { $0.list.id == id }) {
+                    listCards[index].games = games
+                }
+            }
+        }
+    }
 }
 
 extension ListsViewModel {

--- a/GameNetTests/DataSources/List/CoverImageCacheTests.swift
+++ b/GameNetTests/DataSources/List/CoverImageCacheTests.swift
@@ -1,0 +1,43 @@
+//
+//  CoverImageCacheTests.swift
+//  GameNetTests
+//
+//  Created by Alliston Aleixo on 14/08/26.
+//
+
+@testable import GameNet
+import XCTest
+
+final class CoverImageCacheTests: XCTestCase {
+    private let testURL = "https://gamenet.example/cover-cache-test.png"
+
+    override func tearDown() {
+        if let request = CoverImageCache.request(for: testURL) {
+            CoverImageCache.urlCache.removeCachedResponse(for: request)
+        }
+
+        super.tearDown()
+    }
+
+    func testRequest_WhenURLIsEmpty_ShouldReturnNil() {
+        XCTAssertNil(CoverImageCache.request(for: ""))
+        XCTAssertNil(CoverImageCache.request(for: "   "))
+    }
+
+    func testStore_ShouldReturnCachedData() {
+        let pngData = Data(
+            base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )!
+        let url = URL(string: testURL)!
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "image/png"]
+        )!
+
+        CoverImageCache.store(data: pngData, response: response, for: testURL)
+
+        XCTAssertEqual(CoverImageCache.cachedData(for: testURL), pngData)
+    }
+}

--- a/GameNetTests/ViewModel/List/ListCardModelTests.swift
+++ b/GameNetTests/ViewModel/List/ListCardModelTests.swift
@@ -1,0 +1,61 @@
+//
+//  ListCardModelTests.swift
+//  GameNetTests
+//
+//  Created by Alliston Aleixo on 14/08/26.
+//
+
+@testable import GameNet
+import XCTest
+
+final class ListCardModelTests: XCTestCase {
+    func testPreviewGames_WhenMoreThanThree_ShouldReturnFirstThree() {
+        let model = ListCardModel(list: sampleList, games: sampleGames(count: 5))
+
+        XCTAssertEqual(model.previewGames.count, 3)
+        XCTAssertEqual(model.previewGames.map(\.id), ["1", "2", "3"])
+    }
+
+    func testPreviewGames_WhenThreeOrFewer_ShouldReturnAllGames() {
+        XCTAssertEqual(ListCardModel(list: sampleList, games: sampleGames(count: 3)).previewGames.count, 3)
+        XCTAssertEqual(ListCardModel(list: sampleList, games: sampleGames(count: 2)).previewGames.count, 2)
+        XCTAssertEqual(ListCardModel(list: sampleList, games: sampleGames(count: 1)).previewGames.count, 1)
+        XCTAssertTrue(ListCardModel(list: sampleList, games: []).previewGames.isEmpty)
+    }
+
+    func testOverflowCount_WhenMoreThanThree_ShouldBeTotalMinusTwo() {
+        XCTAssertEqual(ListCardModel(list: sampleList, games: sampleGames(count: 15)).overflowCount, 13)
+        XCTAssertEqual(ListCardModel(list: sampleList, games: sampleGames(count: 4)).overflowCount, 2)
+        XCTAssertEqual(ListCardModel(list: sampleList, games: sampleGames(count: 5)).overflowCount, 3)
+    }
+
+    func testOverflowCount_WhenThreeOrFewer_ShouldBeNil() {
+        XCTAssertNil(ListCardModel(list: sampleList, games: sampleGames(count: 3)).overflowCount)
+        XCTAssertNil(ListCardModel(list: sampleList, games: sampleGames(count: 2)).overflowCount)
+        XCTAssertNil(ListCardModel(list: sampleList, games: sampleGames(count: 1)).overflowCount)
+        XCTAssertNil(ListCardModel(list: sampleList, games: []).overflowCount)
+    }
+
+    private var sampleList: GameNet.List {
+        GameNet.List(id: "1", name: "Favoritos")
+    }
+
+    private func sampleGames(count: Int) -> [ListItem] {
+        (1...count).map { index in
+            ListItem(
+                id: "\(index)",
+                name: "Game \(index)",
+                platform: "Switch",
+                userGameId: "user-\(index)",
+                year: 2023,
+                boughtDate: nil,
+                value: 0,
+                start: nil,
+                finish: nil,
+                cover: "https://example.com/\(index).jpg",
+                order: index,
+                comment: nil
+            )
+        }
+    }
+}

--- a/GameNetTests/ViewModel/List/ListsViewModelTests.swift
+++ b/GameNetTests/ViewModel/List/ListsViewModelTests.swift
@@ -17,8 +17,10 @@ class ListsViewModelTests: XCTestCase {
 
     override func setUp() async throws {
         Container.shared.reset()
+        MockListRepository.reset()
 
         cancellables = Set<AnyCancellable>()
+        viewModel = ListsViewModel()
     }
 
     override func tearDown() {
@@ -54,10 +56,32 @@ class ListsViewModelTests: XCTestCase {
         await fulfillment(of: [listsLoadedExpectation], timeout: 30)
     }
 
+    func testLists_ValidData_ShouldLoadGamePreviewsOnCards() async {
+        // Given
+        Container.shared.listRepository.register(factory: { MockListRepository() })
+
+        // When
+        await viewModel.fetchData()
+
+        // Then
+        XCTAssertEqual(viewModel.listCards.count, 2)
+
+        let proximos = viewModel.listCards.first { $0.list.id == "1" }
+        XCTAssertEqual(proximos?.name, "Próximos Jogos")
+        XCTAssertEqual(proximos?.games.count, 5)
+        XCTAssertEqual(proximos?.previewGames.count, 3)
+        XCTAssertEqual(proximos?.overflowCount, 3)
+
+        let zeldas = viewModel.listCards.first { $0.list.id == "2" }
+        XCTAssertEqual(zeldas?.games.count, 2)
+        XCTAssertEqual(zeldas?.previewGames.count, 2)
+        XCTAssertNil(zeldas?.overflowCount)
+    }
+
     // MARK: Private
 
     private let mock = ListResponseMock()
     private let stubRequests = StubRequests()
-    private var viewModel = ListsViewModel()
+    private var viewModel: ListsViewModel!
     private var cancellables: Set<AnyCancellable>!
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## O que mudou

A aba **Listas** deixa de ser uma `List` de nomes e passa a usar **cards de 96px** no estilo combinado (protótipo E):

- Barra vertical na **cor primária** (`Color.main`)
- Capas à direita, recortadas com zoom (`scaledToFill`) para funcionar com artes de tamanhos diferentes
- Título **sobreposto** às capas, numa linha só, com fade navy → transparente
- No terceiro jogo, se a lista tiver **mais de 3** itens, a capa fica desfocada com `+(total − 2)`
- Com 3 jogos, as três capas ficam nítidas; com 1 ou 2, só essas aparecem

Os detalhes de cada lista (capas) são carregados em paralelo depois da listagem, então o nome aparece primeiro e as artes entram em seguida.

## Cache das capas

As três primeiras capas de cada lista entram num `URLCache` próprio (64 MB em memória, 256 MB em disco). Na próxima visita o `CachedAsyncImage` lê do cache na hora, e as URLs dos jogos da lista também reaproveitam o cache HTTP.

## Testes

- `ListCardModelTests`: preview de no máximo 3 capas e overflow `total − 2`
- `ListsViewModelTests`: cards recebem os jogos mockados, incluindo overflow e listas com 2 jogos
- `CoverImageCacheTests`: gravação e leitura do cache de imagens

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fff79-819e-7e43-b578-ec686eddb074?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fff79-819e-7e43-b578-ec686eddb074&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

